### PR TITLE
arris_cablemodem: remove debug output

### DIFF
--- a/arris_cablemodem
+++ b/arris_cablemodem
@@ -179,7 +179,6 @@ def merge_result(data):
 
     # Cache fully good result
     if isgood:
-        print("writing state file")
         with open(os.environ['MUNIN_STATEFILE'], 'w') as f:
             json.dump(data, f, indent=2, sort_keys=True)
 


### PR DESCRIPTION
Printing that debug output causes an error to be logged in munin-update.log.